### PR TITLE
scala-akka-http-quickstart to v0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: scala-akka-http-quickstart
+  repository: http://jenkins-x-chartmuseum:8080
+  version: v0.0.3


### PR DESCRIPTION
Promote scala-akka-http-quickstart to version v0.0.3